### PR TITLE
added wrappers for assertions to enhance reporting and some re-struct…

### DIFF
--- a/src/main/java/POM/WomenPage.java
+++ b/src/main/java/POM/WomenPage.java
@@ -8,6 +8,7 @@ import utils.Interactor;
 public class WomenPage extends BasePage {
 
 	private final By currentPageLink = By.className("woocommerce-breadcrumb");
+	private final By title = By.tagName("h1");
 	
 	public WomenPage(WebDriver driver) {
         super(driver);
@@ -15,5 +16,9 @@ public class WomenPage extends BasePage {
 	
     public String getCurrentPageInNav() {
     	return Interactor.findElement(driver, currentPageLink).getText().split("/")[1].trim();
+    }
+    
+    public String getPageTitle() {
+    	return Interactor.findElement(driver, title).getText();
     }
 }

--- a/src/test/java/selenium/BaseTest.java
+++ b/src/test/java/selenium/BaseTest.java
@@ -1,29 +1,38 @@
-package org.selenium;
+package selenium;
+
 
 import POM.BasePage;
 
 import org.openqa.selenium.WebDriver;
+import org.testng.ITestContext;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
 import utils.DriverManager;
 import utils.Logger;
+import java.lang.reflect.*;
 
 public class BaseTest{
 
     private ThreadLocal<WebDriver> driver = new ThreadLocal<>();
     protected DriverManager driverManager;
+    private ITestContext context;
+    private ThreadLocal<String> currentMethodName = new ThreadLocal<>();
     
-    @BeforeMethod
-    public void navigateToWebsiteToTest(){
+    //I annotated below methods with alwaysRun=true, otherwise they will be ignored due to the current groups config in testng.xml
+    
+    @BeforeMethod(alwaysRun = true)
+    public void navigateToWebsiteToTest(ITestContext context, Method method){
         Logger.Info("BeforeMethod: Creating driver, opening browser and navigating to homepage");
+    	this.context = context;
+    	currentMethodName.set(method.getName());
         driverManager = new DriverManager();
         driver.set(driverManager.getDriver());
         BasePage basePage = new BasePage(getDriver());
         basePage.navigateToMainPage();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void closeBrowser(){
     	Logger.Info("BeforeMethod: Closing driver");
     	driver.get().close();
@@ -32,5 +41,13 @@ public class BaseTest{
     
     public WebDriver getDriver() {
         return driver.get();
+    }
+    
+    public ITestContext getITestContext() {
+    	return context;
+    }
+    
+    public String getCurrentMethodName() {
+    	return currentMethodName.get();
     }
 }

--- a/src/test/java/selenium/askomcdh/LongTests.java
+++ b/src/test/java/selenium/askomcdh/LongTests.java
@@ -1,15 +1,23 @@
-package org.selenium;
+package selenium.askomcdh;
 
-import POJO.BillingAddress;
-import POM.*;
-import org.testng.Assert;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
+
+import POJO.BillingAddress;
+import POM.CartPage;
+import POM.CheckoutPage;
+import POM.CheckoutResults;
+import POM.HeaderBar;
+import POM.MainPage;
+import POM.ProductDetailPage;
+import POM.StorePage;
+import selenium.BaseTest;
+import support.MyAssert;
 import utils.JacksonUtil;
 
-public class TestCase extends BaseTest{
+public class LongTests extends BaseTest {
 
-    @Test @Ignore
+	@Test(groups = {"regression"}) @Ignore
     public void buyAnyProductTest() {
         BillingAddress billingAddress = JacksonUtil.deserializeJson("billingAddress.json", BillingAddress.class);
 
@@ -34,10 +42,11 @@ public class TestCase extends BaseTest{
         checkoutPage.placeOrder();
 
         CheckoutResults checkoutResults = new CheckoutResults(getDriver());
-        Assert.assertEquals(checkoutResults.getCheckoutNotice(),"Thank you. Your order has been received.");
+        MyAssert ma = new MyAssert(getITestContext(),getCurrentMethodName());
+        ma.assertEq(checkoutResults.getCheckoutNotice(),"Thank you. Your order has been received.","Check that checkout message is correct");
     }
 
-    @Test @Ignore
+	@Test(groups = {"regression"})
     public void enterInvalidCouponTest() {
         MainPage mainPage = new MainPage(getDriver());
         mainPage.clickOnSuperiorLink("Store");
@@ -54,34 +63,7 @@ public class TestCase extends BaseTest{
         CartPage cartPage = new CartPage(getDriver());
         cartPage.enterCouponCode("invalid");
 
-        Assert.assertEquals(cartPage.getCouponErrorResult(),"Coupon \"invalid\" does not exist!");
-    }
-    
-    @Test
-    public void storeLinkLeadsToStorePage() {
-    	MainPage mainPage = new MainPage(getDriver());
-    	mainPage.clickOnSuperiorLink("Store");
-
-        StorePage storePage = new StorePage(getDriver());
-        //I will make it fail on purpose just to see a failure on the report
-        Assert.assertEquals("StoreXXX", storePage.getCurrentPageInNav(),"Store link doesn't lead to the expected destination");
-    }
-    
-    @Test
-    public void menLinkLeadsToMenPage() {
-    	MainPage mainPage = new MainPage(getDriver());
-    	mainPage.clickOnSuperiorLink("Men");
-
-        MenPage menPage = new MenPage(getDriver());
-        Assert.assertEquals("Men", menPage.getCurrentPageInNav(),"Men link doesn't lead to the expected destination");
-    }
-    
-    @Test
-    public void womenLinkLeadsToWomenPage() {
-    	MainPage mainPage = new MainPage(getDriver());
-    	mainPage.clickOnSuperiorLink("Women");
-
-        WomenPage womenPage = new WomenPage(getDriver());
-        Assert.assertEquals("Women", womenPage.getCurrentPageInNav(),"Women link doesn't lead to the expected destination");
+        MyAssert ma = new MyAssert(getITestContext(), getCurrentMethodName());
+        ma.assertEq(cartPage.getCouponErrorResult(), "Coupon \"invalid\" does not exist!", "Check that couppon doesn't exist message appears");
     }
 }

--- a/src/test/java/selenium/askomcdh/NumericTests.java
+++ b/src/test/java/selenium/askomcdh/NumericTests.java
@@ -1,0 +1,30 @@
+package selenium.askomcdh;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import selenium.BaseTest;
+import support.MyAssert;
+
+public class NumericTests extends BaseTest{
+
+	//This method will provide data to any test method that declares that its Data Provider is named "data_provider"
+	@DataProvider(name = "data_provider")
+	public Object[][] createData() {
+	 return new Object[][] {
+	   { "Cedric", 36 },
+	   { "Anne", 37},
+	 };
+	}
+	 
+	//This test method declares that its data should be supplied by the Data Provider named "data_provider"
+	//If the data set contains N element the test will run N times, one for each set of data
+	@Test(dataProvider = "data_provider", groups = {"non_browser_tests"})
+	public void numberTests(String name, int age) {
+		//Let's suppose that if the age is a pair number the user can be logged in
+		boolean logged = (age % 2 == 0);
+		
+		MyAssert ma = new MyAssert(getITestContext(), getCurrentMethodName());
+		ma.assertEq(logged, true, "The user wasn't accepted into the system because it's age was a pair number: "+age);
+	}
+}

--- a/src/test/java/selenium/askomcdh/ShortTests.java
+++ b/src/test/java/selenium/askomcdh/ShortTests.java
@@ -1,0 +1,45 @@
+package selenium.askomcdh;
+
+import POM.*;
+import selenium.BaseTest;
+import support.MyAssert;
+import support.MySoftAssert;
+
+import org.testng.annotations.Test;
+
+public class ShortTests extends BaseTest{
+    
+    @Test(groups = {"smoke"})
+    public void storeLinkLeadsToStorePage() {
+    	MainPage mainPage = new MainPage(getDriver());
+    	mainPage.clickOnSuperiorLink("Store");
+        StorePage storePage = new StorePage(getDriver());
+        
+        //I will make it fail on purpose just to see a failure on the report
+        MyAssert ma = new MyAssert(getITestContext(),getCurrentMethodName());
+        ma.assertEq(storePage.getCurrentPageInNav(), "StoreXXX", "Check that Store link leads to a page that contains 'StoreXXX' on its navigation tree");
+    }
+    
+    @Test(groups = {"smoke"})
+    public void menLinkLeadsToMenPage() {
+    	MainPage mainPage = new MainPage(getDriver());
+    	mainPage.clickOnSuperiorLink("Men");
+        MenPage menPage = new MenPage(getDriver());
+        
+        MyAssert ma = new MyAssert(getITestContext(),getCurrentMethodName());
+        ma.assertEq(menPage.getCurrentPageInNav(), "Men", "Check that Men link leads to a page that contains 'Men' on its navigation tree");
+    }
+    
+    @Test(groups = {"smoke"})
+    public void womenLinkLeadsToWomenPage() {
+    	MainPage mainPage = new MainPage(getDriver());
+    	mainPage.clickOnSuperiorLink("Women");
+        WomenPage womenPage = new WomenPage(getDriver());
+
+        MySoftAssert msa = new MySoftAssert(getITestContext(),getCurrentMethodName());
+        //I make one of the SoftAssert fail just to see that it will report both Pass and Fail messages
+        msa.assertEquals(womenPage.getPageTitle(), "W1men", "Check that Women page have 'Women' on its title");
+        msa.assertEquals(womenPage.getCurrentPageInNav(),"Women","Check that Women link leads to a page that contains 'Women' on its navigation tree");
+        msa.assertAll();
+    }
+}

--- a/src/test/java/support/AssertType.java
+++ b/src/test/java/support/AssertType.java
@@ -1,0 +1,6 @@
+package support;
+
+public enum AssertType {
+	STANDARD,
+	SOFT
+}

--- a/src/test/java/support/MyAssert.java
+++ b/src/test/java/support/MyAssert.java
@@ -1,0 +1,50 @@
+package support;
+
+import java.util.ArrayList;
+
+import org.testng.Assert;
+import org.testng.ITestContext;
+
+/*
+ * An assertion will normally throw a message only when it fails.
+ * MyAssert was created to wrap original Assert with the purpose to print the assertion message even when it is passing.
+ * 
+ * To do this we will have to create a method in this class for every assertion that want to be used in the framework. 
+ * For example assertEquals(String, String, String) is one of them. If we want to compare any other data type we should create 
+ * that method which will, at the end, call the original Assert.assertEquals() but in our method we will save the message 
+ * within the test context. Then, whenever the test passes it will print the message.
+ * 
+ * As the massage will end up in an HTML report we can add any formatting we want inside the string.
+ * Note: We use a List of Messages so we can use the same for SoftAssertions in which we need to have 1 message per assertion.
+ */
+
+public class MyAssert extends Assert {
+	
+	private String methodName;
+	private ITestContext context;
+	private MyAssertMessage myAssertMessage;
+	
+	public MyAssert(ITestContext context, String methodName) {
+		this.methodName = methodName;
+		this.context = context;
+		this.myAssertMessage = new MyAssertMessage(AssertType.STANDARD);
+	}
+
+	public void assertEq(String actual, String expected, String message) {
+		ArrayList<String> messages = new ArrayList<String>();
+		messages.add("<i>"+message+" expected ["+expected+"] and found ["+actual+"]</i>");
+		myAssertMessage.setMessages(messages);
+		context.setAttribute(methodName+"_msgs", myAssertMessage);
+		
+		Assert.assertEquals(actual, expected, message);
+	}
+	
+	public void assertEq(boolean actual, boolean expected, String message) {
+		ArrayList<String> messages = new ArrayList<String>();
+		messages.add("<i>"+message+" expected ["+expected+"] and found ["+actual+"]</i>");
+		myAssertMessage.setMessages(messages);
+		context.setAttribute(methodName+"_msgs", myAssertMessage);
+		
+		Assert.assertEquals(actual, expected, message);
+	}
+}

--- a/src/test/java/support/MyAssertMessage.java
+++ b/src/test/java/support/MyAssertMessage.java
@@ -1,0 +1,25 @@
+package support;
+
+import java.util.ArrayList;
+
+public class MyAssertMessage {
+	
+	private ArrayList<String> messages;
+	private AssertType assertType;
+
+	public MyAssertMessage(AssertType assertType) {
+		this.assertType = assertType;
+	}
+	
+	public ArrayList<String> getMessages() {
+		return messages;
+	}
+
+	public void setMessages(ArrayList<String> messages) {
+		this.messages = messages;
+	}
+	
+	public AssertType getAssertType() {
+		return assertType;
+	}
+}

--- a/src/test/java/support/MySoftAssert.java
+++ b/src/test/java/support/MySoftAssert.java
@@ -1,0 +1,53 @@
+package support;
+
+import java.util.ArrayList;
+
+import org.testng.ITestContext;
+import org.testng.asserts.IAssert;
+import org.testng.asserts.SoftAssert;
+
+/*
+ * An assertion will normally throw a message only when it fails.
+ * MySoftAssert was created to wrap original SoftAssert (SA) with the purpose to print the assertion message even when it is passing.
+ * 
+ * To do this we will have to create a method in this class for every assertion that want to be used in the framework. 
+ * For example assertEquals(String, String, String) is one of them. If we want to compare any other data type we should create 
+ * that method which will, at the end, call the original Assert.assertEquals() but in our method we will save the message within 
+ * the test context.
+ * At the end of the SAs it will call assertAll() here two scenarios come into play:
+ *  - If all asserts within the SA passes the test will PASS and one message will be captured per each SA
+ *  - If one or more assert fails the test will be detected as FAIL, however we will save the passed assertions messages
+ *   adding logic the overriden onAssertSuccess method.
+ * 
+ * As the massage will end up in an HTML report we can add any formatting we want inside the string.
+ */
+
+public class MySoftAssert extends SoftAssert {
+
+	private ITestContext context;
+	private ArrayList<String> messages;
+	private String methodName;
+	private MyAssertMessage myAssertMessage;
+	
+	public MySoftAssert(ITestContext context, String methodName) {
+		this.context = context;
+		messages = new ArrayList<String>();
+		this.methodName = methodName;
+		this.myAssertMessage = new MyAssertMessage(AssertType.SOFT);
+	}
+	
+	@Override
+	public void onAssertSuccess(IAssert<?> assertCommand) {
+		String message = assertCommand.getMessage();
+		String expected = assertCommand.getExpected().toString();
+		String actual = assertCommand.getActual().toString();
+		messages.add("<i>"+message+" expected ["+expected+"] and found ["+actual+"]</i>");
+	}
+	
+	@Override
+	public void assertAll() {
+		myAssertMessage.setMessages(messages);
+		context.setAttribute(methodName+"_msgs", myAssertMessage);
+		super.assertAll();
+	}
+}

--- a/testng.xml
+++ b/testng.xml
@@ -2,13 +2,26 @@
 
 <suite name="TestSuite" verbose="1" >
 
-    <test name="Regression1" parallel="methods" thread-count="4">
+	<!-- Currently i'm using 2 threads for running tests as the computer i'm testing on is way too slow -->
+    <test name="Regression1" parallel="methods" thread-count="2">
+		
+		<!-- Groups can be used for example to set up, smoke, functional, regression, etc -->
+		<groups>
+    		<run>
+      			<include name="smoke"/>
+      			<include name="regression"/>
+      			<include name="non_browser_tests"/>
+    		</run>
+  		</groups>
+
         <classes>
-            <class name="org.selenium.TestCase"/>
+            <class name="selenium.askomcdh.ShortTests"/>
+            <class name="selenium.askomcdh.LongTests"/>
+            <class name="selenium.askomcdh.NumericTests"/>
         </classes>
     </test>
     
     <listeners>
-		<listener class-name="org.selenium.MyTestListener"></listener>
+		<listener class-name="support.MyTestListener"></listener>
 	</listeners>
 </suite>


### PR DESCRIPTION
- Include groups to testng.xml and to classes in the form on example.
- Created a wrapper for Assert -> MyAssert & MySoftAssert
- Created a MyAssertMessage to store messages
- Include a message for tests passing in the report. This makes use previously wrapper assertions.
Normally Assertions won't print messages if there are no errors. Now, 100% of messages will be added to the report. 
For Soft Assertions if N assertions pass they will individually show as pass and if N assertions fail, each error will be listed individually but within the same stack trace.
For Standard Assertions if the test pass, the assert message will be shown as pass and if it fails the full strack trace will be added to the report.
- Re organization of the package and folder structure for a clearer framework